### PR TITLE
added closePort() and isPortOpened() functions

### DIFF
--- a/examples/example/mainwindow.cpp
+++ b/examples/example/mainwindow.cpp
@@ -105,6 +105,7 @@ void MainWindow::onInOpenPortButtonClicked(bool value)
 {
     Q_UNUSED(value);
     qDebug()<<"opening input"<<_inPortComboBox->currentText();
+    if(_midiIn->isPortOpen()) _midiIn->closePort();
     _midiIn->openPort(_inPortComboBox->currentIndex());
 }
 
@@ -118,6 +119,7 @@ void MainWindow::onOutOpenPortButtonClicked(bool value)
 {
     Q_UNUSED(value);
     qDebug()<<"opening output"<<_outPortComboBox->currentText();
+    if(_midiOut->isPortOpen()) _midiOut->closePort();
     _midiOut->openPort(_outPortComboBox->currentIndex());
 }
 

--- a/qmidiin.cpp
+++ b/qmidiin.cpp
@@ -36,6 +36,14 @@ void QMidiIn::openPort(QString name)
         }
     }
 }
+void QMidiIn::closePort()
+{
+    _midiIn->closePort();
+}
+bool QMidiIn::isPortOpen()
+{
+    return _midiIn->isPortOpen();
+}
 void QMidiIn::setIgnoreTypes(bool sysex, bool time, bool sense)
 {
     _midiIn->ignoreTypes(sysex, time, sense);

--- a/qmidiin.h
+++ b/qmidiin.h
@@ -16,6 +16,8 @@ public:
     void openPort(QString name);
     void openPort(unsigned int index);
     void openVirtualPort(QString name);
+    void closePort();
+    bool isPortOpen();
     void setIgnoreTypes(bool sysex = true, bool time = true, bool sense = true);
 private:
     void onMidiMessageReceive(QMidiMessage *msg);

--- a/qmidiout.cpp
+++ b/qmidiout.cpp
@@ -24,6 +24,14 @@ void QMidiOut::openVirtualPort(QString name)
 {
     _midiOut->openVirtualPort(name.toStdString());
 }
+void QMidiOut::closePort()
+{
+    _midiOut->closePort();
+}
+bool QMidiOut::isPortOpen()
+{
+    return _midiOut->isPortOpen();
+}
 void QMidiOut::sendNoteOn(unsigned int channel, unsigned int pitch, unsigned int velocity)
 {
     std::vector<unsigned char> message;

--- a/qmidiout.h
+++ b/qmidiout.h
@@ -19,6 +19,8 @@ public:
     void sendRawMessage(std::vector<unsigned char> &message);
     void openPort(unsigned int index);
     void openVirtualPort(QString name);
+    void closePort();
+    bool isPortOpen();
 private:
     RtMidiOut *_midiOut;
 


### PR DESCRIPTION
closePort() can be needed in case the MIDI input/ouput has to be changed on the fly without restarting the app.
The example app is updated accordingly.
