### PR TITLE
Fix Program Change, Aftertouch and empty message

### DIFF
--- a/qmidiin.cpp
+++ b/qmidiin.cpp
@@ -83,7 +83,7 @@ void QMidiIn::callback(double deltatime, std::vector<unsigned char> *message, vo
                 break;
             case MIDI_PROGRAM_CHANGE:
             case MIDI_AFTERTOUCH:
-                midiMessage->setValue((unsigned int) message->at(1));
+                midiMessage->setControl((unsigned int) message->at(1));
                 break;
             case MIDI_PITCH_BEND:
                 midiMessage->setValue((unsigned int) (message->at(2) << 7) +

--- a/qmidimessage.cpp
+++ b/qmidimessage.cpp
@@ -156,13 +156,17 @@ std::vector<unsigned char> QMidiMessage::getRawMessage()
         case MIDI_PROGRAM_CHANGE:{
             _rawMessage.push_back(MIDI_PROGRAM_CHANGE+_channel-1);
             _rawMessage.push_back(_control);
-            _rawMessage.push_back(_value);
             break;
         }
         case MIDI_SYSEX:{
             _rawMessage = _sysExData;
             if(_sysExData.back() != MIDI_SYSEX_END) _rawMessage.push_back(MIDI_SYSEX_END);
             break;
+        }
+         
+        case MIDI_AFTERTOUCH:{
+            _rawMessage.push_back(MIDI_AFTERTOUCH+_channel-1);
+            _rawMessage.push_back(_control);
         }
 
             //TODO: check protocol and implement other cases

--- a/qmidimessage.cpp
+++ b/qmidimessage.cpp
@@ -23,7 +23,7 @@ QMidiMessage::QMidiMessage(const QMidiMessage &other)
     _rawMessage = other._rawMessage;
 }
 
-QMidiMessage *QMidiMessage::clear()
+void QMidiMessage::clear()
 {
     _status = MIDI_UNKNOWN;
     _channel = 1;

--- a/qmidimessage.h
+++ b/qmidimessage.h
@@ -46,7 +46,7 @@ public:
     ~QMidiMessage();
     QMidiMessage(const QMidiMessage &other);
 
-    QMidiMessage* clear();
+    void clear();
     QMidiStatus getStatus();
     unsigned int getChannel();
     unsigned int getPitch();

--- a/qmidiout.cpp
+++ b/qmidiout.cpp
@@ -51,8 +51,11 @@ void QMidiOut::sendNoteOff(unsigned int channel, unsigned int pitch, unsigned in
 void QMidiOut::sendMessage(QMidiMessage *message)
 {
     std::vector<unsigned char> rawMessage = message->getRawMessage();
-    qDebug()<<"send message"<<rawMessage.front();
-    sendRawMessage(rawMessage);
+    if(!rawMessage.empty()){
+        qDebug()<<"send message"<<rawMessage.front();
+        sendRawMessage(rawMessage);
+    }
+    
 }
 
 void QMidiOut::sendRawMessage(std::vector<unsigned char> &message)


### PR DESCRIPTION
Store Program Change and Aftertouch in _control, remove _value in Program Control and add Aftertouch.
Also skip empty message. (Fix #7)